### PR TITLE
Flutter CI Github Action

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -1,0 +1,22 @@
+name: Dart CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    container:
+      image:  google/dart:latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install dependencies
+      run: pub get
+    - name: Run tests
+      run: pub run test

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies
+      working-directory: sledilnik_mobile_app
       run: pub get
     - name: Run tests
+      working-directory: sledilnik_mobile_app
       run: pub run test

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -18,6 +18,9 @@ jobs:
     - uses: actions/checkout@v2
     - uses: subosito/flutter-action@v1.4.0
 
+    - name: install tools
+      run: sudo apt-get install xz-utils
+
     - name: Install dependencies
       working-directory: sledilnik_mobile_app
       run: flutter pub get

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -16,15 +16,16 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: subosito/flutter-action@v1.4.0
 
     - name: install tools
       run: sudo apt-get install xz-utils
 
     - name: Install dependencies
+      uses: subosito/flutter-action@v1.4.0
       working-directory: sledilnik_mobile_app
       run: flutter pub get
 
     - name: Run tests
+      uses: subosito/flutter-action@v1.4.0
       working-directory: sledilnik_mobile_app
       run: flutter test

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -16,9 +16,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - uses: subosito/flutter-action@v1.4.0
+
     - name: Install dependencies
       working-directory: sledilnik_mobile_app
       run: flutter pub get
+
     - name: Run tests
       working-directory: sledilnik_mobile_app
-      run: pub run test
+      run: flutter test

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install dependencies
       working-directory: sledilnik_mobile_app
-      run: pub get
+      run: flutter pub get
     - name: Run tests
       working-directory: sledilnik_mobile_app
       run: pub run test

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -20,12 +20,13 @@ jobs:
     - name: install tools
       run: sudo apt-get install xz-utils
 
-    - name: Install dependencies
+    - name: install flutter
       uses: subosito/flutter-action@v1.4.0
+
+    - name: Install dependencies
       working-directory: sledilnik_mobile_app
       run: flutter pub get
 
     - name: Run tests
-      uses: subosito/flutter-action@v1.4.0
       working-directory: sledilnik_mobile_app
       run: flutter test

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -11,17 +11,9 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    #container:
-    #  image:  google/dart:latest
-
     steps:
     - uses: actions/checkout@v2
-
-    - name: install tools
-      run: sudo apt-get install xz-utils
-
-    - name: install flutter
-      uses: subosito/flutter-action@v1.4.0
+    - uses: subosito/flutter-action@v1.4.0
 
     - name: Install dependencies
       working-directory: sledilnik_mobile_app

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -19,9 +19,13 @@ jobs:
       working-directory: sledilnik_mobile_app
       run: flutter pub get
 
+    #- name: Run tests
+    #  working-directory: sledilnik_mobile_app
+    #  run: flutter test
+
     - name: Build Android APK
       working-directory: sledilnik_mobile_app
-      run: flutter build apk
+      run: flutter build apk --target-platform android-arm,android-arm64,android-x64 --split-per-abi
 
     - name: Build Android app bundle
       working-directory: sledilnik_mobile_app
@@ -30,7 +34,3 @@ jobs:
     #- name: Build iOS app
     #  working-directory: sledilnik_mobile_app
     #  run: flutter build ios
-
-    - name: Run tests
-      working-directory: sledilnik_mobile_app
-      run: flutter test

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -19,6 +19,18 @@ jobs:
       working-directory: sledilnik_mobile_app
       run: flutter pub get
 
+    - name: Build Android APK
+      working-directory: sledilnik_mobile_app
+      run: flutter build apk
+
+    - name: Build Android app bundle
+      working-directory: sledilnik_mobile_app
+      run: flutter build appbundle
+
+    - name: Build iOS app
+      working-directory: sledilnik_mobile_app
+      run: flutter build ios
+
     - name: Run tests
       working-directory: sledilnik_mobile_app
       run: flutter test

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -27,9 +27,9 @@ jobs:
       working-directory: sledilnik_mobile_app
       run: flutter build appbundle
 
-    - name: Build iOS app
-      working-directory: sledilnik_mobile_app
-      run: flutter build ios
+    #- name: Build iOS app
+    #  working-directory: sledilnik_mobile_app
+    #  run: flutter build ios
 
     - name: Run tests
       working-directory: sledilnik_mobile_app

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -1,4 +1,4 @@
-name: Dart CI
+name: Flutter CI
 
 on:
   push:
@@ -11,8 +11,8 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    container:
-      image:  google/dart:latest
+    #container:
+    #  image:  google/dart:latest
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Prepares the Flutter environment (using https://github.com/marketplace/actions/flutter-action ) and makes android builds.

See it running at https://github.com/stefanb/sledilnik-mobile-app/actions

Tests are currently failing and should be fixed separately and uncommented in the `flutter.yaml`

Later we can add building also for iOS and publishing artefacts when release tags are added.

I suggest to squash merge this to keep the git history simpler & cleaner.