### PR TITLE
Adjust coloring parameters to support all sledilnik.org info boxes

### DIFF
--- a/sledilnik_mobile_app/lib/ui/widgets/info_box.dart
+++ b/sledilnik_mobile_app/lib/ui/widgets/info_box.dart
@@ -24,12 +24,13 @@ class InfoBox extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
-    TrendType trendType;
-    if (deltaIn == null && deltaOut == null) {
-      trendType = TrendType.Death;
-    } else {
-      trendType = (deltaIn ?? 0) > (deltaOut ?? 0) ? TrendType.Bad : TrendType.Good;
-    }
+
+    TrendType trendType = (death != null && deltaIn == null)
+        ? TrendType.Death
+        : _relativeDelta < 0
+            ? TrendType.Good
+            : TrendType.Bad;
+
     final trendColor = colorScheme.getTrendColor(trendType);
     return Container(
         padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 8.0),


### PR DESCRIPTION
On sledilnik.org are two more info boxes, which, to be supported, will need this change to the coloring of the right side text.

See screenshot for info box with red text in the case when only the leftmost value is supplied. This means that the death text color is used only in the case where we have the third data value without having the first.

<img width="195" alt="Screenshot 2020-11-05 at 07 39 00" src="https://user-images.githubusercontent.com/8921/98206566-65b72e00-1f3a-11eb-8b16-a5a70eed56d6.png">
